### PR TITLE
re-enable capture widget

### DIFF
--- a/source/class/capture/Capture.js
+++ b/source/class/capture/Capture.js
@@ -103,6 +103,7 @@ qx.Class.define("capture.Capture",
       this.getContentElement().getDomElement().appendChild(video.getMediaObject());
       qx.bom.element.Transform.scale(this.getContentElement().getDomElement(), [-1, 1]);
       this._updateCaptureArea();
+      video.play();
     }, this);
     this.__video = video;
 
@@ -211,11 +212,12 @@ qx.Class.define("capture.Capture",
         stream.onended = function(e) {
           that.fireEvent("stop"); 
         };
-      
+        
         that.getContentElement().getDomElement().appendChild(that.__video.getMediaObject());
         that.__stream = stream;
         that.fireEvent("start"); 
-      }, function(){
+
+      }, function(error){
         that.__msg.setValue(this.tr("Error capturing the video stream!"));
         that.__msg.show();
         that.__stop();
@@ -333,8 +335,10 @@ qx.Class.define("capture.Capture",
     __getUserMedia : function(props, success, error) {
       if (navigator.webkitGetUserMedia) {
         return navigator.webkitGetUserMedia(props, success, error);
-      } else if (navigator.getUserMedia) {
-        return navigator.mediaDevices.getUserMedia(props, success, error);
+      } else if (navigator.mediaDevices.getUserMedia) {
+        return navigator.mediaDevices.getUserMedia(props)
+          .then(success)
+          .catch(error);
       } else {
         return undefined; 
       }

--- a/source/class/capture/Capture.js
+++ b/source/class/capture/Capture.js
@@ -332,9 +332,9 @@ qx.Class.define("capture.Capture",
      */
     __getUserMedia : function(props, success, error) {
       if (navigator.webkitGetUserMedia) {
-        return navigator.webkitGetUserMedia(props, success, error)
+        return navigator.webkitGetUserMedia(props, success, error);
       } else if (navigator.getUserMedia) {
-        return navigator.getUserMedia(props, success, error)
+        return navigator.mediaDevices.getUserMedia(props, success, error);
       } else {
         return undefined; 
       }

--- a/source/class/capture/Capture.js
+++ b/source/class/capture/Capture.js
@@ -205,7 +205,7 @@ qx.Class.define("capture.Capture",
         that.__video.onerror = function(e) {
           that.__msg.setValue(this.tr("Error capturing the video stream!"));
           that.__msg.show();
-          stream.stop();
+          that.__stop();
         };
       
         stream.onended = function(e) {
@@ -215,6 +215,10 @@ qx.Class.define("capture.Capture",
         that.getContentElement().getDomElement().appendChild(that.__video.getMediaObject());
         that.__stream = stream;
         that.fireEvent("start"); 
+      }, function(){
+        that.__msg.setValue(this.tr("Error capturing the video stream!"));
+        that.__msg.show();
+        that.__stop();
       });
     },
 
@@ -227,7 +231,11 @@ qx.Class.define("capture.Capture",
         return;
       }
 
-      this.__stream.stop();
+      var msTracks = this.__stream.getTracks();
+      for (var track in msTracks){
+        msTracks[track].stop();
+      }
+
       this.__stream = null;
     },
 
@@ -261,7 +269,7 @@ qx.Class.define("capture.Capture",
      * @return {boolean}
      */  
     isSupported : function() {
-        return navigator.getUserMedia != undefined || navigator.webkitGetUserMedia != undefined;
+        return navigator.mediaDevices.getUserMedia != undefined || navigator.webkitGetUserMedia != undefined;
     },
 
     // overridden
@@ -322,11 +330,11 @@ qx.Class.define("capture.Capture",
      * Wrap getUserMedia to be a bit more browser independent. Could
      * use qx.bom.client later on.
      */
-    __getUserMedia : function(props, callback) {
+    __getUserMedia : function(props, success, error) {
       if (navigator.webkitGetUserMedia) {
-        return navigator.webkitGetUserMedia(props, callback)
+        return navigator.webkitGetUserMedia(props, success, error)
       } else if (navigator.getUserMedia) {
-        return navigator.getUserMedia(props, callback)
+        return navigator.getUserMedia(props, success, error)
       } else {
         return undefined; 
       }


### PR DESCRIPTION
Use navigator.mediaDevices.getUserMedia instead of deprecated and dropped navigator.getUserMedia
for firefox.

Added missing third parameter for all browsers.

Since Firefox 37
https://bugzilla.mozilla.org/show_bug.cgi?id=1149494

it seems to be necessary to call videoElement.play() explicit in "loadeddata" / "loadedmetadata" listener.
Otherwise the stream will block.

This should keep the widget useable for now.
